### PR TITLE
refactor(register): No more inner class from the ClientRegister

### DIFF
--- a/src/main/java/mc/duzo/timeless/client/TimelessClient.java
+++ b/src/main/java/mc/duzo/timeless/client/TimelessClient.java
@@ -1,37 +1,21 @@
 package mc.duzo.timeless.client;
 
-import java.util.function.Supplier;
-
-import mc.duzo.animation.api.AnimationEvents;
-import mc.duzo.animation.generic.AnimationInfo;
-import mc.duzo.animation.player.holder.PlayerAnimationHolder;
-import mc.duzo.animation.registry.AnimationRegistry;
-import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
-
-import net.minecraft.util.Identifier;
-
-import mc.duzo.timeless.Timeless;
 import mc.duzo.timeless.client.gui.JarvisGui;
 import mc.duzo.timeless.client.gui.UtilityBeltGui;
 import mc.duzo.timeless.client.keybind.TimelessKeybinds;
 import mc.duzo.timeless.client.network.ClientNetwork;
+import mc.duzo.timeless.client.render.TimelessAnimations;
 import mc.duzo.timeless.client.render.entity.IronManEntityRenderer;
 import mc.duzo.timeless.core.TimelessEntityTypes;
-import mc.duzo.timeless.suit.Suit;
 import mc.duzo.timeless.suit.client.ClientSuitRegistry;
-import mc.duzo.timeless.suit.client.animation.SuitAnimationHolder;
-import mc.duzo.timeless.suit.client.animation.impl.ironman.generic.GenericIronManAnimations;
-import mc.duzo.timeless.suit.client.animation.impl.ironman.mk5.MarkFiveAnimations;
-import mc.duzo.timeless.suit.client.animation.impl.ironman.mk5.MarkFiveCaseAnimation;
-import mc.duzo.timeless.suit.client.animation.impl.ironman.mk5.MarkFiveMaskAnimation;
-import mc.duzo.timeless.suit.ironman.client.sentry.SentryAnimation;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 
 public class TimelessClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        ClientRegister.init();
+        TimelessAnimations.init();
         ClientNetwork.init();
         ClientSuitRegistry.init();
         TimelessKeybinds.init();
@@ -42,68 +26,8 @@ public class TimelessClient implements ClientModInitializer {
         });
     }
 
-
-    public static class ClientRegister {
-        public static void init() {
-            Animations.init();
-            Renderers.init();
-        }
-
-        public static class Animations {
-
-            public static class Players {
-                public static final Supplier<PlayerAnimationHolder> MARK_FIVE_CASE_OPEN = AnimationRegistry.instance().register(() -> new PlayerAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_mk5_case_open_player"), MarkFiveAnimations.CASE_OPEN_PLAYER));
-                public static final Supplier<PlayerAnimationHolder> MARK_FIVE_CASE_CLOSE = AnimationRegistry.instance().register(() -> new PlayerAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_mk5_case_close_player"), MarkFiveAnimations.CASE_CLOSE_PLAYER));
-
-                public static void init() {}
-
-            }
-            public static class Suits {
-                public static class MarkFive {
-                    public static final Supplier<MarkFiveCaseAnimation> CASE_OPEN = AnimationRegistry.instance().register(() -> new MarkFiveCaseAnimation(true));
-                    public static final Supplier<MarkFiveCaseAnimation> CASE_CLOSE = AnimationRegistry.instance().register(() -> new MarkFiveCaseAnimation(false));
-                    public static final Supplier<MarkFiveMaskAnimation> MASK_OPEN = AnimationRegistry.instance().register(() -> new MarkFiveMaskAnimation(true));
-                    public static final Supplier<MarkFiveMaskAnimation> MASK_CLOSE = AnimationRegistry.instance().register(() -> new MarkFiveMaskAnimation(false));
-
-                    public static void init() {
-
-                    }
-                }
-                public static class IronMan {
-                    public static final Supplier<MarkFiveMaskAnimation> MASK_OPEN = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_mask_open"), GenericIronManAnimations.MASK_OPEN, new AnimationInfo(AnimationInfo.RenderType.TORSO_HEAD, null, AnimationInfo.Movement.ALLOW, AnimationInfo.Transform.TARGETED), false));
-                    public static final Supplier<MarkFiveMaskAnimation> MASK_CLOSE = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_mask_close"), GenericIronManAnimations.MASK_CLOSE, new AnimationInfo(AnimationInfo.RenderType.TORSO_HEAD, null, AnimationInfo.Movement.ALLOW, AnimationInfo.Transform.TARGETED), false));
-                    public static final Supplier<SuitAnimationHolder> BACK_OPEN = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_back_open"), SentryAnimation.SUIT_OPEN, new AnimationInfo(AnimationInfo.RenderType.ALL, AnimationInfo.Perspective.THIRD_PERSON_BACK, AnimationInfo.Movement.DISABLE, AnimationInfo.Transform.ALL), false));
-                    public static final Supplier<SuitAnimationHolder> BACK_CLOSE = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_back_close"), SentryAnimation.SUIT_OPEN2, new AnimationInfo(AnimationInfo.RenderType.ALL, AnimationInfo.Perspective.THIRD_PERSON_BACK, AnimationInfo.Movement.DISABLE, AnimationInfo.Transform.ALL), false));
-
-                    public static void init() {
-
-                    }
-                }
-
-                public static void init() {
-                    IronMan.init();
-                    MarkFive.init();
-
-                    AnimationEvents.FIND_ANIMATION_INFO.register(player -> {
-                        Suit suit = Suit.findSuit(player).orElse(null);
-                        if (suit == null) return AnimationEvents.Result.pass();
-
-                        return new AnimationEvents.Result<>(suit.toClient().getAnimationInfo(player));
-                    });
-                }
-            }
-
-            public static void init() {
-                Players.init();
-                Suits.init();
-            }
-        }
-
-        public static class Renderers {
-            public static void init() {
-                EntityRendererRegistry.register(TimelessEntityTypes.IRON_MAN, IronManEntityRenderer::new);
-            }
-        }
+    public static void registerRenderers() {
+        EntityRendererRegistry.register(TimelessEntityTypes.IRON_MAN, IronManEntityRenderer::new);
     }
 
 }

--- a/src/main/java/mc/duzo/timeless/client/render/TimelessAnimations.java
+++ b/src/main/java/mc/duzo/timeless/client/render/TimelessAnimations.java
@@ -1,0 +1,44 @@
+package mc.duzo.timeless.client.render;
+
+import mc.duzo.animation.api.AnimationEvents;
+import mc.duzo.animation.generic.AnimationInfo;
+import mc.duzo.animation.player.holder.PlayerAnimationHolder;
+import mc.duzo.animation.registry.AnimationRegistry;
+import mc.duzo.timeless.Timeless;
+import mc.duzo.timeless.suit.Suit;
+import mc.duzo.timeless.suit.client.animation.SuitAnimationHolder;
+import mc.duzo.timeless.suit.client.animation.impl.ironman.generic.GenericIronManAnimations;
+import mc.duzo.timeless.suit.client.animation.impl.ironman.mk5.MarkFiveAnimations;
+import mc.duzo.timeless.suit.client.animation.impl.ironman.mk5.MarkFiveCaseAnimation;
+import mc.duzo.timeless.suit.client.animation.impl.ironman.mk5.MarkFiveMaskAnimation;
+import mc.duzo.timeless.suit.ironman.client.sentry.SentryAnimation;
+import net.minecraft.util.Identifier;
+
+import java.util.function.Supplier;
+
+public class TimelessAnimations {
+	// PLAYERS
+	public static final Supplier<PlayerAnimationHolder> PLAYER_MARK_FIVE_CASE_OPEN = AnimationRegistry.instance().register(() -> new PlayerAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_mk5_case_open_player"), MarkFiveAnimations.CASE_OPEN_PLAYER));
+	public static final Supplier<PlayerAnimationHolder> PLAYER_MARK_FIVE_CASE_CLOSE = AnimationRegistry.instance().register(() -> new PlayerAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_mk5_case_close_player"), MarkFiveAnimations.CASE_CLOSE_PLAYER));
+
+	// MARK FIVE
+	public static final Supplier<MarkFiveCaseAnimation> MARK_FIVE_CASE_OPEN = AnimationRegistry.instance().register(() -> new MarkFiveCaseAnimation(true));
+	public static final Supplier<MarkFiveCaseAnimation> MARK_FIVE_CASE_CLOSE = AnimationRegistry.instance().register(() -> new MarkFiveCaseAnimation(false));
+	public static final Supplier<MarkFiveMaskAnimation> MARK_FIVE_MASK_OPEN = AnimationRegistry.instance().register(() -> new MarkFiveMaskAnimation(true));
+	public static final Supplier<MarkFiveMaskAnimation> MARK_FIVE_MASK_CLOSE = AnimationRegistry.instance().register(() -> new MarkFiveMaskAnimation(false));
+
+	// GENERIC IRON MAN
+	public static final Supplier<MarkFiveMaskAnimation> GENERIC_IRONMAN_MASK_OPEN = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_mask_open"), GenericIronManAnimations.MASK_OPEN, new AnimationInfo(AnimationInfo.RenderType.TORSO_HEAD, null, AnimationInfo.Movement.ALLOW, AnimationInfo.Transform.TARGETED), false));
+	public static final Supplier<MarkFiveMaskAnimation> GENERIC_IRONMAN_MASK_CLOSE = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_mask_close"), GenericIronManAnimations.MASK_CLOSE, new AnimationInfo(AnimationInfo.RenderType.TORSO_HEAD, null, AnimationInfo.Movement.ALLOW, AnimationInfo.Transform.TARGETED), false));
+	public static final Supplier<SuitAnimationHolder> GENERIC_IRONMAN_BACK_OPEN = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_back_open"), SentryAnimation.SUIT_OPEN, new AnimationInfo(AnimationInfo.RenderType.ALL, AnimationInfo.Perspective.THIRD_PERSON_BACK, AnimationInfo.Movement.DISABLE, AnimationInfo.Transform.ALL), false));
+	public static final Supplier<SuitAnimationHolder> GENERIC_IRONMAN_BACK_CLOSE = AnimationRegistry.instance().register(() -> new SuitAnimationHolder(new Identifier(Timeless.MOD_ID, "ironman_generic_back_close"), SentryAnimation.SUIT_OPEN2, new AnimationInfo(AnimationInfo.RenderType.ALL, AnimationInfo.Perspective.THIRD_PERSON_BACK, AnimationInfo.Movement.DISABLE, AnimationInfo.Transform.ALL), false));
+
+	public static void init() {
+		AnimationEvents.FIND_ANIMATION_INFO.register(player -> {
+			Suit suit = Suit.findSuit(player).orElse(null);
+			if (suit == null) return AnimationEvents.Result.pass();
+
+			return new AnimationEvents.Result<>(suit.toClient().getAnimationInfo(player));
+		});
+	}
+}

--- a/src/main/java/mc/duzo/timeless/suit/ironman/client/sentry/SentryAnimation.java
+++ b/src/main/java/mc/duzo/timeless/suit/ironman/client/sentry/SentryAnimation.java
@@ -4,13 +4,13 @@ import java.util.Optional;
 
 import dev.drtheo.scheduler.api.TimeUnit;
 
+import mc.duzo.timeless.client.render.TimelessAnimations;
 import net.minecraft.client.render.entity.animation.Animation;
 import net.minecraft.client.render.entity.animation.AnimationHelper;
 import net.minecraft.client.render.entity.animation.Keyframe;
 import net.minecraft.client.render.entity.animation.Transformation;
 import net.minecraft.entity.player.PlayerEntity;
 
-import mc.duzo.timeless.client.TimelessClient;
 import mc.duzo.timeless.power.PowerRegistry;
 import mc.duzo.timeless.suit.client.animation.SuitAnimationHolder;
 import mc.duzo.timeless.suit.client.animation.SuitAnimationTracker;
@@ -49,7 +49,7 @@ public class SentryAnimation {
         if (open != wasOpen) {
             System.out.println(open);
 
-            SuitAnimationTracker.getInstance().add(this.cached.getUuid(), (open) ? TimelessClient.ClientRegister.Animations.Suits.IronMan.BACK_OPEN.get() : TimelessClient.ClientRegister.Animations.Suits.IronMan.BACK_CLOSE.get());
+            SuitAnimationTracker.getInstance().add(this.cached.getUuid(), (open) ? TimelessAnimations.Suits.IronMan.BACK_OPEN.get() : TimelessAnimations.Suits.IronMan.BACK_CLOSE.get());
             wasOpen = open;
         }
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Split everything from ClientRegister into their own classes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Very messy
closes #46 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
`TimelessClient.ClientRegister` exploded into `TimelessAnimations` etc

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->