### PR TITLE
feat(suit): per slot rendering

### DIFF
--- a/src/main/java/mc/duzo/timeless/client/gui/JarvisGui.java
+++ b/src/main/java/mc/duzo/timeless/client/gui/JarvisGui.java
@@ -5,6 +5,7 @@ import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.util.Colors;
 import net.minecraft.util.math.ColorHelper;
 import net.minecraft.util.math.Direction;
@@ -26,7 +27,7 @@ public class JarvisGui {
         if (player == null) return;
         if (client.gameRenderer.getCamera().isThirdPerson()) return;
 
-        Suit suit = Suit.findSuit(player).orElse(null);
+        Suit suit = Suit.findSuit(player, EquipmentSlot.HEAD).orElse(null);
         if (suit == null) return;
         if (!(suit.hasPower(PowerRegistry.JARVIS))) return;
         if (suit.hasPower(PowerRegistry.MASK_TOGGLE) && !(MaskTogglePower.hasMask(player))) return;

--- a/src/main/java/mc/duzo/timeless/client/gui/UtilityBeltGui.java
+++ b/src/main/java/mc/duzo/timeless/client/gui/UtilityBeltGui.java
@@ -1,8 +1,11 @@
 package mc.duzo.timeless.client.gui;
 
+import mc.duzo.timeless.suit.Suit;
+import mc.duzo.timeless.suit.batman.BatmanSuit;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.util.Identifier;
 
 import mc.duzo.timeless.Timeless;
@@ -18,6 +21,10 @@ public class UtilityBeltGui {
 
         ClientPlayerEntity player = client.player;
         if (player == null) return;
+
+        Suit suit = Suit.findSuit(player, EquipmentSlot.LEGS).orElse(null);
+        if (suit == null) return;
+        if (!(suit instanceof BatmanSuit)) return;
 
         int i = scaledWidth / 2;
 

--- a/src/main/java/mc/duzo/timeless/core/items/SuitItem.java
+++ b/src/main/java/mc/duzo/timeless/core/items/SuitItem.java
@@ -65,7 +65,8 @@ public abstract class SuitItem extends ArmorItem implements Identifiable {
             ItemStack stack = entity.getEquippedStack(EquipmentSlot.CHEST);
 
             if (stack == null) return null;
-            if (!(stack.getItem() instanceof SuitItem)) return null;
+            if (!(stack.getItem() instanceof SuitItem item)) return null;
+            if (!item.getSuit().getSet().isWearing(entity)) return null;
 
             return stack.getOrCreateSubNbt("SuitData");
         }

--- a/src/main/java/mc/duzo/timeless/mixin/EntityMixin.java
+++ b/src/main/java/mc/duzo/timeless/mixin/EntityMixin.java
@@ -1,5 +1,6 @@
 package mc.duzo.timeless.mixin;
 
+import net.minecraft.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,7 +24,7 @@ public abstract class EntityMixin {
         Entity entity = (Entity)(Object)this;
         if (!(entity instanceof PlayerEntity player)) return;
 
-        Suit suit = Suit.findSuit(player).orElse(null);
+        Suit suit = Suit.findSuit(player, EquipmentSlot.LEGS).orElse(Suit.findSuit(player, EquipmentSlot.FEET).orElse(null));
         if (suit == null) return;
 
         this.playSound(suit.getStepSound(), 0.2f, player.getRandom().nextBetween(9, 11) / 10f);

--- a/src/main/java/mc/duzo/timeless/mixin/client/PlayerEntityRendererMixin.java
+++ b/src/main/java/mc/duzo/timeless/mixin/client/PlayerEntityRendererMixin.java
@@ -1,5 +1,6 @@
 package mc.duzo.timeless.mixin.client;
 
+import net.minecraft.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -35,7 +36,7 @@ public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<Abs
 
     @Inject(method = "renderArm" , at = @At("HEAD"), cancellable = true)
     private void timeless$renderArm(MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, AbstractClientPlayerEntity player, ModelPart arm, ModelPart sleeve, CallbackInfo ci){
-        Suit suit = Suit.findSuit(player).orElse(null);
+        Suit suit = Suit.findSuit(player, EquipmentSlot.CHEST).orElse(null);
         if (suit == null) return;
         ClientSuit clientSuit = suit.toClient();
         if (!(clientSuit.hasModel())) return;

--- a/src/main/java/mc/duzo/timeless/suit/Suit.java
+++ b/src/main/java/mc/duzo/timeless/suit/Suit.java
@@ -1,15 +1,6 @@
 package mc.duzo.timeless.suit;
 
-import java.util.Optional;
-
 import mc.duzo.animation.registry.Identifiable;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
-import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.sound.SoundEvent;
-
 import mc.duzo.timeless.core.items.SuitItem;
 import mc.duzo.timeless.datagen.provider.lang.Translatable;
 import mc.duzo.timeless.power.Power;
@@ -17,11 +8,26 @@ import mc.duzo.timeless.power.PowerList;
 import mc.duzo.timeless.suit.client.ClientSuit;
 import mc.duzo.timeless.suit.client.ClientSuitRegistry;
 import mc.duzo.timeless.suit.set.SuitSet;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.sound.SoundEvent;
+
+import java.util.Optional;
 
 public abstract class Suit implements Identifiable, Translatable {
-    public static Optional<Suit> findSuit(LivingEntity entity) {
-        if (!(entity.getEquippedStack(EquipmentSlot.CHEST).getItem() instanceof SuitItem item)) return Optional.empty();
+    public static Optional<Suit> findSuit(LivingEntity entity, EquipmentSlot slot) {
+        if (!(entity.getEquippedStack(slot).getItem() instanceof SuitItem item)) return Optional.empty();
         return Optional.ofNullable(item.getSuit());
+    }
+
+    public static Optional<Suit> findSuit(LivingEntity entity) {
+        for (EquipmentSlot slot : EquipmentSlot.values()) {
+            Optional<Suit> suit = findSuit(entity, slot);
+            if (suit.isPresent()) return suit;
+        }
+        return Optional.empty();
     }
 
     public abstract boolean isBinding();

--- a/src/main/java/mc/duzo/timeless/suit/batman/sixer/client/model/Batman66Model.java
+++ b/src/main/java/mc/duzo/timeless/suit/batman/sixer/client/model/Batman66Model.java
@@ -9,6 +9,7 @@ import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.RotationAxis;
 
@@ -72,6 +73,36 @@ public class Batman66Model extends SuitModel {
 
         ModelPartData LeftLeg = modelPartData.addChild("LeftLeg", ModelPartBuilder.create().uv(0, 48).cuboid(-2.0F, 0.0F, -2.0F, 4.0F, 12.0F, 4.0F, new Dilation(0.35F)), ModelTransform.pivot(1.9F, 12.0F, 0.0F));
         return TexturedModelData.of(modelData, 128, 128);
+    }
+
+    @Override
+    public void setVisibilityForSlot(EquipmentSlot slot) {
+        switch (slot) {
+            case HEAD -> {
+                this.head.visible = true;
+                this.body.visible = false;
+                this.leftArm.visible = false;
+                this.rightArm.visible = false;
+                this.leftLeg.visible = false;
+                this.rightLeg.visible = false;
+            }
+            case CHEST -> {
+                this.head.visible = false;
+                this.body.visible = true;
+                this.leftArm.visible = true;
+                this.rightArm.visible = true;
+                this.leftLeg.visible = false;
+                this.rightLeg.visible = false;
+            }
+            case LEGS, FEET -> {
+                this.head.visible = false;
+                this.body.visible = false;
+                this.leftArm.visible = false;
+                this.rightArm.visible = false;
+                this.leftLeg.visible = true;
+                this.rightLeg.visible = true;
+            }
+        }
     }
 
     @Override

--- a/src/main/java/mc/duzo/timeless/suit/client/render/SuitFeature.java
+++ b/src/main/java/mc/duzo/timeless/suit/client/render/SuitFeature.java
@@ -1,5 +1,7 @@
 package mc.duzo.timeless.suit.client.render;
 
+import mc.duzo.timeless.core.items.SuitItem;
+import mc.duzo.timeless.suit.Suit;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.LightmapTextureManager;
 import net.minecraft.client.render.RenderLayer;
@@ -15,10 +17,6 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 
-import mc.duzo.timeless.core.items.SuitItem;
-import mc.duzo.timeless.suit.Suit;
-import mc.duzo.timeless.suit.set.SuitSet;
-
 public class SuitFeature<T extends LivingEntity, M extends EntityModel<T>>
         extends FeatureRenderer<T, M> {
 
@@ -31,19 +29,27 @@ public class SuitFeature<T extends LivingEntity, M extends EntityModel<T>>
 
     @Override
     public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f, float g, float h, float j, float k, float l) {
-        this.updateModel(findSuit(livingEntity));
+        for (EquipmentSlot slot : EquipmentSlot.values()) {
+            if (slot.getType() != EquipmentSlot.Type.ARMOR) continue;
+
+            matrixStack.push();
+            this.renderPart(matrixStack, vertexConsumerProvider, i, livingEntity, f, g, h, j, k, l, slot);
+            matrixStack.pop();
+        }
+    }
+
+    private void renderPart(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity, float f, float g, float h, float j, float k, float l, EquipmentSlot slot) {
+        this.updateModel(findSuit(livingEntity, slot));
 
         if (suit == null) return;
 
         if (livingEntity.isInvisible() && !suit.isAlwaysVisible()) return;
 
-        SuitSet set = suit.getSet();
-        if (!(set.isWearing(livingEntity))) return; // todo this check every frame is bad
-
         VertexConsumer consumer = vertexConsumerProvider.getBuffer(RenderLayer.getEntityTranslucent(model.texture()));
 
         BipedEntityModel<?> context = (BipedEntityModel<?>) this.getContextModel();
 
+        model.setVisibilityForSlot(slot);
         model.copyFrom(context);
         model.setAngles(livingEntity, f, g, j, k, l);
 
@@ -53,7 +59,7 @@ public class SuitFeature<T extends LivingEntity, M extends EntityModel<T>>
 
         model.render(livingEntity, h, matrixStack, consumer, i, 1, 1, 1, 1);
 
-        if (livingEntity instanceof AbstractClientPlayerEntity player) {
+        if (livingEntity instanceof AbstractClientPlayerEntity player && slot == EquipmentSlot.CHEST) {
             model.preRenderCape(matrixStack, consumer, player, i, h);
         }
 
@@ -72,8 +78,8 @@ public class SuitFeature<T extends LivingEntity, M extends EntityModel<T>>
         }
     }
 
-    private static Suit findSuit(LivingEntity entity) {
-        ItemStack chest = entity.getEquippedStack(EquipmentSlot.CHEST);
+    private static Suit findSuit(LivingEntity entity, EquipmentSlot slot) {
+        ItemStack chest = entity.getEquippedStack(slot);
         if (!(chest.getItem() instanceof SuitItem item)) return null;
 
         return item.getSuit();

--- a/src/main/java/mc/duzo/timeless/suit/client/render/SuitModel.java
+++ b/src/main/java/mc/duzo/timeless/suit/client/render/SuitModel.java
@@ -1,9 +1,9 @@
 package mc.duzo.timeless.suit.client.render;
 
-import java.util.Optional;
-
 import mc.duzo.animation.generic.AnimationInfo;
-
+import mc.duzo.timeless.suit.client.ClientSuit;
+import mc.duzo.timeless.suit.client.animation.SuitAnimationHolder;
+import mc.duzo.timeless.suit.client.animation.SuitAnimationTracker;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.VertexConsumer;
@@ -11,21 +11,25 @@ import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
 import net.minecraft.client.render.entity.model.EntityModel;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RotationAxis;
 
-import mc.duzo.timeless.suit.client.ClientSuit;
-import mc.duzo.timeless.suit.client.animation.SuitAnimationHolder;
-import mc.duzo.timeless.suit.client.animation.SuitAnimationTracker;
+import java.util.Optional;
 
 public abstract class SuitModel extends EntityModel<LivingEntity> {
     /**
-     * This will be called to render the model, perform all adjustments here and render the model using the proper method.
+     * This will be called to render the entire model, perform all adjustments here and render the model using the proper method.
      */
     public abstract void render(LivingEntity entity, float tickDelta, MatrixStack matrices, VertexConsumer vertexConsumers, int light, float r, float g, float b, float alpha);
     public abstract void renderArm(boolean isRight, AbstractClientPlayerEntity player, int i, MatrixStack matrices, VertexConsumer buffer, int light, int i1, int i2, int i3, int i4);
+
+    /**
+     * Sets the visibility of the model parts for the given slot.
+     */
+    public abstract void setVisibilityForSlot(EquipmentSlot slot);
 
     /**
      * This is not the method you want to override for rendering the model.

--- a/src/main/java/mc/duzo/timeless/suit/ironman/client/GenericIronManModel.java
+++ b/src/main/java/mc/duzo/timeless/suit/ironman/client/GenericIronManModel.java
@@ -8,6 +8,7 @@ import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.RotationAxis;
 import net.minecraft.util.math.Vec3d;
@@ -348,6 +349,35 @@ public abstract class GenericIronManModel extends SuitModel {
         this.leftLeg.pivotX -= this.body.roll * 3f * 3.2f;
     }
 
+    @Override
+    public void setVisibilityForSlot(EquipmentSlot slot) {
+        switch (slot) {
+            case HEAD -> {
+                this.head.visible = true;
+                this.body.visible = false;
+                this.leftArm.visible = false;
+                this.rightArm.visible = false;
+                this.leftLeg.visible = false;
+                this.rightLeg.visible = false;
+            }
+            case CHEST -> {
+                this.head.visible = false;
+                this.body.visible = true;
+                this.leftArm.visible = true;
+                this.rightArm.visible = true;
+                this.leftLeg.visible = false;
+                this.rightLeg.visible = false;
+            }
+            case LEGS, FEET -> {
+                this.head.visible = false;
+                this.body.visible = false;
+                this.leftArm.visible = false;
+                this.rightArm.visible = false;
+                this.leftLeg.visible = true;
+                this.rightLeg.visible = true;
+            }
+        }
+    }
 
     @Override
     public void renderArm(boolean isRight, AbstractClientPlayerEntity player, int i, MatrixStack matrices, VertexConsumer buffer, int light, int i1, int i2, int i3, int i4) {

--- a/src/main/java/mc/duzo/timeless/suit/ironman/client/sentry/SentryAnimation.java
+++ b/src/main/java/mc/duzo/timeless/suit/ironman/client/sentry/SentryAnimation.java
@@ -1,22 +1,20 @@
 package mc.duzo.timeless.suit.ironman.client.sentry;
 
-import java.util.Optional;
-
 import dev.drtheo.scheduler.api.TimeUnit;
-
 import mc.duzo.timeless.client.render.TimelessAnimations;
-import net.minecraft.client.render.entity.animation.Animation;
-import net.minecraft.client.render.entity.animation.AnimationHelper;
-import net.minecraft.client.render.entity.animation.Keyframe;
-import net.minecraft.client.render.entity.animation.Transformation;
-import net.minecraft.entity.player.PlayerEntity;
-
 import mc.duzo.timeless.power.PowerRegistry;
 import mc.duzo.timeless.suit.client.animation.SuitAnimationHolder;
 import mc.duzo.timeless.suit.client.animation.SuitAnimationTracker;
 import mc.duzo.timeless.suit.client.render.SuitModel;
 import mc.duzo.timeless.suit.ironman.IronManEntity;
 import mc.duzo.timeless.util.CachableResult;
+import net.minecraft.client.render.entity.animation.Animation;
+import net.minecraft.client.render.entity.animation.AnimationHelper;
+import net.minecraft.client.render.entity.animation.Keyframe;
+import net.minecraft.client.render.entity.animation.Transformation;
+import net.minecraft.entity.player.PlayerEntity;
+
+import java.util.Optional;
 
 public class SentryAnimation {
     private final SuitModel parent;
@@ -49,7 +47,7 @@ public class SentryAnimation {
         if (open != wasOpen) {
             System.out.println(open);
 
-            SuitAnimationTracker.getInstance().add(this.cached.getUuid(), (open) ? TimelessAnimations.Suits.IronMan.BACK_OPEN.get() : TimelessAnimations.Suits.IronMan.BACK_CLOSE.get());
+            SuitAnimationTracker.getInstance().add(this.cached.getUuid(), (open) ? TimelessAnimations.GENERIC_IRONMAN_BACK_OPEN.get() : TimelessAnimations.GENERIC_IRONMAN_BACK_CLOSE.get());
             wasOpen = open;
         }
     }

--- a/src/main/java/mc/duzo/timeless/suit/ironman/mk5/client/MarkFiveModel.java
+++ b/src/main/java/mc/duzo/timeless/suit/ironman/mk5/client/MarkFiveModel.java
@@ -8,6 +8,7 @@ import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.model.BipedEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.RotationAxis;
 import net.minecraft.util.math.Vec3d;
@@ -255,6 +256,37 @@ public class MarkFiveModel extends SuitModel {
                 .uv(93, 115).cuboid(-4.0F, -6.0F, -1.0F, 8.0F, 2.0F, 2.0F, new Dilation(0.0F)), ModelTransform.pivot(0.0F, 0.0F, 0.0F));
         return TexturedModelData.of(modelData, 256, 256);
     }
+
+    @Override
+    public void setVisibilityForSlot(EquipmentSlot slot) {
+        switch (slot) {
+            case HEAD -> {
+                this.head.visible = true;
+                this.body.visible = false;
+                this.leftArm.visible = false;
+                this.rightArm.visible = false;
+                this.leftLeg.visible = false;
+                this.rightLeg.visible = false;
+            }
+            case CHEST -> {
+                this.head.visible = false;
+                this.body.visible = true;
+                this.leftArm.visible = true;
+                this.rightArm.visible = true;
+                this.leftLeg.visible = false;
+                this.rightLeg.visible = false;
+            }
+            case LEGS, FEET -> {
+                this.head.visible = false;
+                this.body.visible = false;
+                this.leftArm.visible = false;
+                this.rightArm.visible = false;
+                this.leftLeg.visible = true;
+                this.rightLeg.visible = true;
+            }
+        }
+    }
+
     @Override
     public void render(LivingEntity entity, float tickDelta, MatrixStack matrices, VertexConsumer vertexConsumers, int light, float r, float g, float b, float alpha) {
         matrices.push();


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Each slot now renders seperately instead of needing the whole set for the model to show

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Looks better

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->
![image](https://github.com/user-attachments/assets/d7202e20-10f5-4834-b2b8-4003b01262e9)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
`SuitModel#setVisibilityForSlot`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
feat(suit): per slot rendering
fix: UtilityBeltGui always rendering