### PR TITLE
chore: switch amblekit to dev.amble:lib 1.1.16-dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,23 @@ repositories {
         }
     }
 
-    maven { url "https://theo.is-a.dev/maven-repo/" }
+    // AmbleKit (https://github.com/amblelabs/modkit, used by https://github.com/amblelabs/ait)
+    maven {
+        url "https://amblelabs.dev/maven"
+
+        content {
+            includeGroup "dev.amble"
+        }
+    }
+
+    // MultiDim, Scheduler, Queue
+    maven {
+        url "https://theo.is-a.dev/maven/"
+
+        content {
+            includeGroup "dev.drtheo"
+        }
+    }
 }
 
 fabricApi {
@@ -49,7 +65,11 @@ dependencies {
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modImplementation("maven.modrinth:amblekit:${project.sakitus_version}") {
+    modImplementation("dev.amble:lib:${project.amblekit_version}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
+
+    modImplementation("maven.modrinth:animator:${project.animator_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,5 @@ archives_base_name=timeless
 
 # Dependencies
 fabric_version=0.92.2+1.20.1
-sakitus_version=1.1.11-1.20.1-beta
+amblekit_version=1.1.16-dev+mc.1.20.1
+animator_version=1.0.1.20-1.20.1-release


### PR DESCRIPTION
Migrates the amblekit dependency from the Modrinth-published `maven.modrinth:amblekit:1.1.11-1.20.1-beta` to the canonical `dev.amble:lib:1.1.16-dev+mc.1.20.1` coordinates published at https://amblelabs.dev/maven, matching the pattern used by [amblelabs/modkit](https://github.com/amblelabs/modkit) (the source of amblekit itself) and [amblelabs/ait](https://github.com/amblelabs/ait) (its largest consumer).

## Changes

**`build.gradle`**
- Added the `https://amblelabs.dev/maven` repository with `includeGroup "dev.amble"`.
- Replaced `modImplementation("maven.modrinth:amblekit:${project.sakitus_version}")` with `modImplementation("dev.amble:lib:${project.amblekit_version}")`.
- Migrated theo's maven from `https://theo.is-a.dev/maven-repo/` to `https://theo.is-a.dev/maven/` (the old URL now 404s) and scoped it to `includeGroup "dev.drtheo"`. This is required because the new amblekit pulls in `dev.drtheo:multidim`, `dev.drtheo:scheduler`, and `dev.drtheo:queue` as transitive deps.
- Added an explicit `modImplementation("maven.modrinth:animator:${project.animator_version}")` dep. The old amblekit bundled Animator transitively; the new `dev.amble:lib` does not, so Animator now needs to be declared directly. The codebase already imports from `mc.duzo.animation.*` in many places.

**`gradle.properties`**
- Removed `sakitus_version=1.1.11-1.20.1-beta`.
- Added `amblekit_version=1.1.16-dev+mc.1.20.1` (latest stable from amblelabs.dev/maven).
- Added `animator_version=1.0.1.20-1.20.1-release` (latest 1.20.1 release on Modrinth).

## Verification

- `./gradlew compileJava` succeeds cleanly with only the pre-existing deprecation/unchecked warnings.
- All `dev.amble.lib.*` and `mc.duzo.animation.*` imports in the codebase resolve against the new dependency stack.
- No source code changes; this PR is build-config only.

## Notes

- This brings the project's dep stack in line with AIT, which makes future cross-pollination of fixes / pattern updates between the two mods easier.
- The bump from 1.1.11 to 1.1.16-dev is several minor releases worth of changes; if any amblekit API has shifted under us in that range, it'll show up at compile or runtime. The clean compile suggests any drift is non-breaking for the surface this mod uses today.