### PR TITLE
ci: fix donator builds (action v1.2 was unpublished)

### DIFF
--- a/.github/workflows/publish-devbuilds.yml
+++ b/.github/workflows/publish-devbuilds.yml
@@ -49,16 +49,19 @@ jobs:
       #  BETA: 1 # exclude assets if it's a beta dev build
 
     - name: Publish artifacts
-      uses: DrTheodor/discord-webhook-upload-action@v1.2
+      uses: drtheodor/discord-webhook-upload-action@v0.2
       with:
         url: ${{ secrets.DEV_BUILDS }}
-        file: 'build/libs/*'
         username: tony stank
         avatar: 'https://img.asmedia.epimg.net/resizer/v2/5R475RB4FZAOJIDICEZLRYLDZM.jpg?auth=e8fe4ea252b5bf7424148eb36e30055f04fc07cd4b2cb88e8f94bee7b8346ac0&width=1472&height=1104&smart=true'
-        commit: '> :sparkles: [%MESSAGE%](<%LINK%>) by [%AUTHOR%](<%AUTHOR_LINK%>)'
-        message: |
+        message_commit: '> :sparkles: [${commitMessage}](<${commitUrl}>) by [${authorName}](<${authorUrl}>)'
+        message_header: |
           <:new1:1253371736510959636><:new2:1253371805734015006> New `Timeless Heroes` dev build `#${{ github.run_number }}`:
-          %COMMITS%
+        file: |
+          build/libs/*.jar
+          !build/libs/*-sources.jar
+          !build/libs/*-dev.jar
+          !build/libs/*-javadoc.jar
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.

--- a/.github/workflows/publish-devbuilds.yml
+++ b/.github/workflows/publish-devbuilds.yml
@@ -49,7 +49,7 @@ jobs:
       #  BETA: 1 # exclude assets if it's a beta dev build
 
     - name: Publish artifacts
-      uses: drtheodor/discord-webhook-upload-action@v0.2
+      uses: drtheodor/discord-webhook-upload-action@1959209c809d121da994387257f14502a8350452 # v0.2
       with:
         url: ${{ secrets.DEV_BUILDS }}
         username: tony stank

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ archives_base_name=timeless
 fabric_version=0.92.2+1.20.1
 amblekit_version=1.1.16-dev+mc.1.20.1
 animator_version=1.0.1.20-1.20.1-release
+# trigger: ci-fix-donator-builds-verification (will be reverted)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,3 @@ archives_base_name=timeless
 fabric_version=0.92.2+1.20.1
 amblekit_version=1.1.16-dev+mc.1.20.1
 animator_version=1.0.1.20-1.20.1-release
-# trigger: ci-fix-donator-builds-verification (will be reverted)


### PR DESCRIPTION
## Root cause

Recent donator-build runs fail in 6-7s, before any Gradle step:

> `Unable to resolve action drtheodor/discord-webhook-upload-action@v1.2, unable to find version v1.2`

The action's tag scheme was reset around Aug 2025 (current tags: `v0.1`, `v0.2`, `v0.3`), removing the `v1.2` we were pinned to. Last successful build was 2025-08-06 - matches the timing.

## Fix

Mirrored the working config from `amblelabs/fakeplayer`'s `publish_devbuilds.yml`:

- Action: `drtheodor/discord-webhook-upload-action@1959209c809d121da994387257f14502a8350452` (pinned to commit SHA - resolves to `v0.2`, which is fakeplayer's known-good version). SHA-pinned per Copilot review feedback so a future tag retag/delete cannot break the build like `v1.2` did. Mirrors how `gradle/actions/setup-gradle@417ae3...` is already pinned in this same file.
- Input rename: `commit` -> `message_commit`, `message` -> `message_header` (input shape changed in the v0.x rewrite)
- Placeholder syntax: `%MESSAGE%` -> `${commitMessage}`, etc.
- Artifact upload now globs to skip `-sources`, `-dev`, `-javadoc` jars instead of dumping everything in `build/libs/`

Preserved this repo's existing triggers (paths-based on any branch). Did not adopt fakeplayer's branches-only model - that's a separate behaviour change.

## Verification

End-to-end verified on this branch via a temporary `gradle.properties` touch (the `paths:` filter only matches src / Gradle file changes, so a workflow-only edit will not trigger the workflow itself - thanks Copilot for catching that). Push-triggered run came back fully green in 1m45s including the previously-failing **Publish artifacts** step. Trigger commit reverted before merge.

(Aside: `workflow_dispatch` mode of this action is broken upstream - it does `payload.commits.flatMap(...)` and `payload.commits` is undefined on dispatch events. Real push events work fine, which is what the workflow actually fires on.)

## Out of scope

- The trigger model (paths-based vs branches-based) - keeping current behaviour
- Bumping to `v0.3` - fakeplayer pins to `v0.2` and that's known-good; can revisit later