### PR TITLE
perf: cache first-person suit arm model

### DIFF
--- a/src/main/java/mc/duzo/timeless/mixin/client/PlayerEntityRendererMixin.java
+++ b/src/main/java/mc/duzo/timeless/mixin/client/PlayerEntityRendererMixin.java
@@ -2,6 +2,7 @@ package mc.duzo.timeless.mixin.client;
 
 import net.minecraft.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -20,12 +21,16 @@ import net.minecraft.util.Arm;
 import mc.duzo.timeless.suit.Suit;
 import mc.duzo.timeless.suit.client.ClientSuit;
 import mc.duzo.timeless.suit.client.render.SuitFeature;
+import mc.duzo.timeless.suit.client.render.SuitModel;
 
 @Mixin(PlayerEntityRenderer.class)
 public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
     public PlayerEntityRendererMixin(EntityRendererFactory.Context ctx, PlayerEntityModel<AbstractClientPlayerEntity> model, float shadowRadius) {
         super(ctx, model, shadowRadius);
     }
+
+    @Unique private ClientSuit timeless$cachedSuit;
+    @Unique private SuitModel timeless$cachedArmModel;
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void timeless$PlayerEntityRenderer(EntityRendererFactory.Context ctx, boolean slim, CallbackInfo ci) {
@@ -41,9 +46,13 @@ public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<Abs
         ClientSuit clientSuit = suit.toClient();
         if (!(clientSuit.hasModel())) return;
 
+        if (this.timeless$cachedSuit != clientSuit) {
+            this.timeless$cachedSuit = clientSuit;
+            this.timeless$cachedArmModel = clientSuit.model().get();
+        }
+
         boolean isRight = player.getMainArm() == Arm.RIGHT;
-        // todo - this will create a new model every frame, which is bad
-        clientSuit.model().get().renderArm(isRight, player, 0, matrices, vertexConsumers.getBuffer(RenderLayer.getEntityTranslucent(clientSuit.texture())), light, 1, 1, 1, 1);
+        this.timeless$cachedArmModel.renderArm(isRight, player, 0, matrices, vertexConsumers.getBuffer(RenderLayer.getEntityTranslucent(clientSuit.texture())), light, 1, 1, 1, 1);
         ci.cancel();
     }
 }

--- a/src/main/java/mc/duzo/timeless/mixin/client/PlayerEntityRendererMixin.java
+++ b/src/main/java/mc/duzo/timeless/mixin/client/PlayerEntityRendererMixin.java
@@ -18,6 +18,8 @@ import net.minecraft.client.render.entity.model.PlayerEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Arm;
 
+import java.util.function.Supplier;
+
 import mc.duzo.timeless.suit.Suit;
 import mc.duzo.timeless.suit.client.ClientSuit;
 import mc.duzo.timeless.suit.client.render.SuitFeature;
@@ -44,12 +46,13 @@ public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<Abs
         Suit suit = Suit.findSuit(player, EquipmentSlot.CHEST).orElse(null);
         if (suit == null) return;
         ClientSuit clientSuit = suit.toClient();
-        if (!(clientSuit.hasModel())) return;
 
         if (this.timeless$cachedSuit != clientSuit) {
             this.timeless$cachedSuit = clientSuit;
-            this.timeless$cachedArmModel = clientSuit.model().get();
+            Supplier<SuitModel> supplier = clientSuit.model();
+            this.timeless$cachedArmModel = supplier == null ? null : supplier.get();
         }
+        if (this.timeless$cachedArmModel == null) return;
 
         boolean isRight = player.getMainArm() == Arm.RIGHT;
         this.timeless$cachedArmModel.renderArm(isRight, player, 0, matrices, vertexConsumers.getBuffer(RenderLayer.getEntityTranslucent(clientSuit.texture())), light, 1, 1, 1, 1);


### PR DESCRIPTION
## Problem

\`PlayerEntityRendererMixin#timeless\$renderArm\` previously called \`clientSuit.model().get()\` on every frame:

\`\`\`java
// todo - this will create a new model every frame, which is bad
clientSuit.model().get().renderArm(...);
\`\`\`

The supplier returned by \`ClientSuit.model()\` is non-memoised - each \`get()\` returns a fresh \`SuitModel\` instance, which in concrete subclasses (e.g. \`MarkFiveModel\`) means rebuilding a \`TexturedModelData\` via hundreds of \`cuboid(...)\` calls. In first-person view this fires every frame.

## Fix

Cache the resolved model on the mixin. Same pattern \`SuitFeature.updateModel\` already uses (\`SuitFeature.java:72\`): track the last-seen \`ClientSuit\` and only regenerate when it changes.

\`\`\`java
@Unique private ClientSuit timeless\$cachedSuit;
@Unique private SuitModel timeless\$cachedArmModel;

if (this.timeless\$cachedSuit != clientSuit) {
    this.timeless\$cachedSuit = clientSuit;
    this.timeless\$cachedArmModel = clientSuit.model().get();
}
this.timeless\$cachedArmModel.renderArm(...);
\`\`\`

\`ClientSuit\` instances are registry-singletons so identity comparison is correct.

## Verification

\`./gradlew compileJava\` clean. The visible behaviour change is that the player's first-person arm no longer re-allocates its model 60-200 times per second while wearing a suit.