### PR TITLE
refactor: keybindsync to fabricpacket + plug movement leak

### DIFF
--- a/src/main/java/mc/duzo/timeless/client/keybind/KeybindSync.java
+++ b/src/main/java/mc/duzo/timeless/client/keybind/KeybindSync.java
@@ -1,13 +1,10 @@
 package mc.duzo.timeless.client.keybind;
 
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.network.PacketByteBuf;
 
-import mc.duzo.timeless.util.ServerKeybind;
+import mc.duzo.timeless.network.c2s.UpdateInputC2SPacket;
 
 public class KeybindSync {
     private static boolean jumpingLast = false;
@@ -27,18 +24,6 @@ public class KeybindSync {
         rightLast = player.input.pressingRight;
         backLast = player.input.pressingBack;
 
-        toServer(jumpingLast, forwardLast, leftLast, rightLast, backLast);
-    }
-
-    public static void toServer(Boolean... args) {
-        PacketByteBuf buf = PacketByteBufs.create();
-
-        buf.writeUuid(MinecraftClient.getInstance().player.getUuid());
-
-        for (Boolean b : args) {
-            buf.writeBoolean(b);
-        }
-
-        ClientPlayNetworking.send(ServerKeybind.UPDATE, buf);
+        ClientPlayNetworking.send(new UpdateInputC2SPacket(jumpingLast, forwardLast, leftLast, rightLast, backLast));
     }
 }

--- a/src/main/java/mc/duzo/timeless/network/Network.java
+++ b/src/main/java/mc/duzo/timeless/network/Network.java
@@ -17,11 +17,13 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
 import mc.duzo.timeless.Timeless;
+import mc.duzo.timeless.network.c2s.UpdateInputC2SPacket;
 import mc.duzo.timeless.network.c2s.UsePowerC2SPacket;
 
 public class Network {
     static {
         ServerPlayNetworking.registerGlobalReceiver(UsePowerC2SPacket.TYPE, UsePowerC2SPacket::handle);
+        ServerPlayNetworking.registerGlobalReceiver(UpdateInputC2SPacket.TYPE, UpdateInputC2SPacket::handle);
     }
 
     public static void init() {

--- a/src/main/java/mc/duzo/timeless/network/c2s/UpdateInputC2SPacket.java
+++ b/src/main/java/mc/duzo/timeless/network/c2s/UpdateInputC2SPacket.java
@@ -1,0 +1,43 @@
+package mc.duzo.timeless.network.c2s;
+
+import net.fabricmc.fabric.api.networking.v1.FabricPacket;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.PacketType;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+import mc.duzo.timeless.Timeless;
+import mc.duzo.timeless.util.ServerKeybind;
+
+public record UpdateInputC2SPacket(boolean jumping, boolean forward, boolean left, boolean right, boolean back) implements FabricPacket {
+    public static final PacketType<UpdateInputC2SPacket> TYPE = PacketType.create(new Identifier(Timeless.MOD_ID, "update_input"), UpdateInputC2SPacket::new);
+
+    public UpdateInputC2SPacket(PacketByteBuf buf) {
+        this(buf.readBoolean(), buf.readBoolean(), buf.readBoolean(), buf.readBoolean(), buf.readBoolean());
+    }
+
+    @Override
+    public void write(PacketByteBuf buf) {
+        buf.writeBoolean(jumping);
+        buf.writeBoolean(forward);
+        buf.writeBoolean(left);
+        buf.writeBoolean(right);
+        buf.writeBoolean(back);
+    }
+
+    @Override
+    public PacketType<?> getType() {
+        return TYPE;
+    }
+
+    public void handle(ServerPlayerEntity source, PacketSender response) {
+        ServerKeybind.Keymap map = ServerKeybind.get(source);
+        map.setJumping(jumping);
+        map.setForward(forward);
+        map.setLeft(left);
+        map.setRight(right);
+        map.setBackward(back);
+    }
+}

--- a/src/main/java/mc/duzo/timeless/util/ServerKeybind.java
+++ b/src/main/java/mc/duzo/timeless/util/ServerKeybind.java
@@ -3,38 +3,22 @@ package mc.duzo.timeless.util;
 import java.util.HashMap;
 import java.util.UUID;
 
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 
-import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.Identifier;
-
-import mc.duzo.timeless.Timeless;
 
 public class ServerKeybind {
-    public static final Identifier UPDATE = new Identifier(Timeless.MOD_ID, "update");
+    public static final HashMap<UUID, Keymap> MOVEMENT = new HashMap<>();
 
     static {
-        ServerPlayNetworking.registerGlobalReceiver(UPDATE, (server, player, handler, buf, responseSender) -> process(buf));
+        ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> MOVEMENT.remove(handler.getPlayer().getUuid()));
     }
-    public static final HashMap<UUID, Keymap> MOVEMENT = new HashMap<>();
 
     public static Keymap get(UUID id) {
         return MOVEMENT.computeIfAbsent(id, k -> new Keymap());
     }
     public static Keymap get(ServerPlayerEntity player) {
         return get(player.getUuid());
-    }
-
-    public static void process(PacketByteBuf data) {
-        UUID id = data.readUuid();
-
-        Keymap map = get(id);
-        map.setJumping(data.readBoolean());
-        map.setForward(data.readBoolean());
-        map.setLeft(data.readBoolean());
-        map.setRight(data.readBoolean());
-        map.setBackward(data.readBoolean());
     }
 
     public static class Keymap extends HashMap<String, Boolean> {


### PR DESCRIPTION
Migrates the last raw-Identifier-based packet in the mod to \`FabricPacket\`, so the codebase has one networking idiom instead of two. Also plugs the \`ServerKeybind.MOVEMENT\` map's unbounded growth (Important #12 from the original review).

## Changes

**New: \`network/c2s/UpdateInputC2SPacket.java\`**
- Record with 5 booleans (\`jumping, forward, left, right, back\`)
- Dropped the UUID from the wire format - server already knows the sender via \`ServerPlayerEntity source\`, so passing the UUID was both redundant and a minor spoofing risk
- \`handle\` writes directly into \`ServerKeybind.MOVEMENT\` for the source player

**\`network/Network.java\`**
- Register the new packet alongside \`UsePowerC2SPacket\`

**\`client/keybind/KeybindSync.java\`**
- \`toServer\` is now a single \`ClientPlayNetworking.send(new UpdateInputC2SPacket(...))\`
- Removed the manual \`PacketByteBuf\` plumbing and the redundant \`MinecraftClient.getInstance().player.getUuid()\` write

**\`util/ServerKeybind.java\`**
- Removed \`UPDATE\` Identifier and \`process(PacketByteBuf)\` (logic moved to the packet's \`handle\`)
- Removed the manual \`ServerPlayNetworking.registerGlobalReceiver\` static block
- Added a \`ServerPlayConnectionEvents.DISCONNECT\` listener that removes the player's entry from \`MOVEMENT\` on disconnect, plugging the leak

## Verification

\`./gradlew compileJava\` clean. Grep for \`ServerKeybind.UPDATE\` and \`ServerKeybind.process\` returns zero matches across the codebase, confirming nothing else still depends on the old API surface.

## Out of scope

The \`Keymap extends HashMap<String, Boolean>\` anti-pattern flagged in the review is preserved here (only the network layer is being touched). That's a separate refactor candidate.