### PR TITLE
refactor: move suit state from chest nbt to player attachment

### DIFF
--- a/src/main/java/mc/duzo/timeless/client/network/ClientNetwork.java
+++ b/src/main/java/mc/duzo/timeless/client/network/ClientNetwork.java
@@ -3,10 +3,12 @@ package mc.duzo.timeless.client.network;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 
 import mc.duzo.timeless.network.s2c.UpdateFlyingStatusS2CPacket;
+import mc.duzo.timeless.network.s2c.UpdateSuitDataS2CPacket;
 
 public class ClientNetwork {
     static {
         ClientPlayNetworking.registerGlobalReceiver(UpdateFlyingStatusS2CPacket.TYPE, UpdateFlyingStatusS2CPacket::handle);
+        ClientPlayNetworking.registerGlobalReceiver(UpdateSuitDataS2CPacket.TYPE, UpdateSuitDataS2CPacket::handle);
     }
 
     public static void init() {

--- a/src/main/java/mc/duzo/timeless/core/items/SuitItem.java
+++ b/src/main/java/mc/duzo/timeless/core/items/SuitItem.java
@@ -18,7 +18,10 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 
+import mc.duzo.timeless.network.Network;
+import mc.duzo.timeless.network.s2c.UpdateSuitDataS2CPacket;
 import mc.duzo.timeless.suit.Suit;
+import mc.duzo.timeless.util.SuitDataAccess;
 
 public abstract class SuitItem extends ArmorItem implements Identifiable {
     private final Suit parent;
@@ -67,13 +70,8 @@ public abstract class SuitItem extends ArmorItem implements Identifiable {
 
     public static class Data {
         public static NbtCompound get(LivingEntity entity) {
-            ItemStack stack = entity.getEquippedStack(EquipmentSlot.CHEST);
-
-            if (stack == null) return null;
-            if (!(stack.getItem() instanceof SuitItem item)) return null;
-            if (!item.getSuit().getSet().isWearing(entity)) return null;
-
-            return stack.getOrCreateSubNbt("SuitData");
+            if (!(entity instanceof SuitDataAccess access)) return null;
+            return access.timeless$getSuitData();
         }
         public static NbtElement get(LivingEntity entity, String key) {
             NbtCompound data = get(entity);
@@ -84,6 +82,29 @@ public abstract class SuitItem extends ArmorItem implements Identifiable {
             NbtCompound data = get(entity);
             if (data == null) return;
             data.put(key, value);
+            sync(entity);
+        }
+        public static void putBoolean(LivingEntity entity, String key, boolean value) {
+            NbtCompound data = get(entity);
+            if (data == null) return;
+            data.putBoolean(key, value);
+            sync(entity);
+        }
+        public static boolean getBoolean(LivingEntity entity, String key) {
+            NbtCompound data = get(entity);
+            if (data == null) return false;
+            return data.getBoolean(key);
+        }
+        public static boolean contains(LivingEntity entity, String key) {
+            NbtCompound data = get(entity);
+            if (data == null) return false;
+            return data.contains(key);
+        }
+        public static void sync(LivingEntity entity) {
+            if (!(entity instanceof ServerPlayerEntity sp)) return;
+            NbtCompound data = get(sp);
+            if (data == null) return;
+            Network.toTracking(new UpdateSuitDataS2CPacket(sp.getUuid(), data), sp);
         }
     }
 }

--- a/src/main/java/mc/duzo/timeless/core/items/SuitItem.java
+++ b/src/main/java/mc/duzo/timeless/core/items/SuitItem.java
@@ -2,6 +2,10 @@ package mc.duzo.timeless.core.items;
 
 import mc.duzo.animation.registry.Identifiable;
 
+import net.fabricmc.fabric.api.networking.v1.EntityTrackingEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
@@ -69,6 +73,37 @@ public abstract class SuitItem extends ArmorItem implements Identifiable {
     }
 
     public static class Data {
+        private static final String LEGACY_KEY = "SuitData";
+
+        static {
+            ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+                ServerPlayerEntity player = handler.getPlayer();
+                migrateLegacy(player);
+                sync(player);
+            });
+
+            EntityTrackingEvents.START_TRACKING.register((tracked, watcher) -> {
+                if (!(tracked instanceof ServerPlayerEntity sp)) return;
+                NbtCompound data = get(sp);
+                if (data == null) return;
+                ServerPlayNetworking.send(watcher, new UpdateSuitDataS2CPacket(sp.getUuid(), data));
+            });
+        }
+
+        private static void migrateLegacy(ServerPlayerEntity player) {
+            if (!(player instanceof SuitDataAccess access)) return;
+            if (!access.timeless$getSuitData().isEmpty()) return;
+
+            ItemStack chest = player.getEquippedStack(EquipmentSlot.CHEST);
+            if (!(chest.getItem() instanceof SuitItem)) return;
+            if (!chest.hasNbt()) return;
+            NbtCompound chestNbt = chest.getNbt();
+            if (!chestNbt.contains(LEGACY_KEY)) return;
+
+            access.timeless$setSuitData(chestNbt.getCompound(LEGACY_KEY).copy());
+            chestNbt.remove(LEGACY_KEY);
+        }
+
         public static NbtCompound get(LivingEntity entity) {
             if (!(entity instanceof SuitDataAccess access)) return null;
             return access.timeless$getSuitData();

--- a/src/main/java/mc/duzo/timeless/mixin/PlayerEntityMixin.java
+++ b/src/main/java/mc/duzo/timeless/mixin/PlayerEntityMixin.java
@@ -1,0 +1,40 @@
+package mc.duzo.timeless.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+
+import mc.duzo.timeless.util.SuitDataAccess;
+
+@Mixin(PlayerEntity.class)
+public abstract class PlayerEntityMixin implements SuitDataAccess {
+    @Unique private static final String NBT_KEY = "TimelessSuitData";
+    @Unique private NbtCompound timeless$suitData = new NbtCompound();
+
+    @Override
+    public NbtCompound timeless$getSuitData() {
+        return this.timeless$suitData;
+    }
+
+    @Override
+    public void timeless$setSuitData(NbtCompound nbt) {
+        this.timeless$suitData = nbt == null ? new NbtCompound() : nbt;
+    }
+
+    @Inject(method = "writeCustomDataToNbt", at = @At("TAIL"))
+    private void timeless$writeCustomDataToNbt(NbtCompound nbt, CallbackInfo ci) {
+        nbt.put(NBT_KEY, this.timeless$suitData);
+    }
+
+    @Inject(method = "readCustomDataFromNbt", at = @At("TAIL"))
+    private void timeless$readCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
+        if (nbt.contains(NBT_KEY)) {
+            this.timeless$suitData = nbt.getCompound(NBT_KEY);
+        }
+    }
+}

--- a/src/main/java/mc/duzo/timeless/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/mc/duzo/timeless/mixin/ServerPlayerEntityMixin.java
@@ -1,0 +1,20 @@
+package mc.duzo.timeless.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import mc.duzo.timeless.util.SuitDataAccess;
+
+@Mixin(ServerPlayerEntity.class)
+public abstract class ServerPlayerEntityMixin {
+    @Inject(method = "copyFrom", at = @At("TAIL"))
+    private void timeless$copyFrom(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfo ci) {
+        SuitDataAccess source = (SuitDataAccess) oldPlayer;
+        SuitDataAccess target = (SuitDataAccess) this;
+        target.timeless$setSuitData(source.timeless$getSuitData().copy());
+    }
+}

--- a/src/main/java/mc/duzo/timeless/network/s2c/UpdateSuitDataS2CPacket.java
+++ b/src/main/java/mc/duzo/timeless/network/s2c/UpdateSuitDataS2CPacket.java
@@ -1,0 +1,42 @@
+package mc.duzo.timeless.network.s2c;
+
+import java.util.UUID;
+
+import net.fabricmc.fabric.api.networking.v1.FabricPacket;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
+import net.fabricmc.fabric.api.networking.v1.PacketType;
+
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+
+import mc.duzo.timeless.Timeless;
+import mc.duzo.timeless.util.SuitDataAccess;
+
+public record UpdateSuitDataS2CPacket(UUID player, NbtCompound data) implements FabricPacket {
+    public static final PacketType<UpdateSuitDataS2CPacket> TYPE = PacketType.create(new Identifier(Timeless.MOD_ID, "update_suit_data"), UpdateSuitDataS2CPacket::new);
+
+    public UpdateSuitDataS2CPacket(PacketByteBuf buf) {
+        this(buf.readUuid(), buf.readNbt());
+    }
+
+    @Override
+    public void write(PacketByteBuf buf) {
+        buf.writeUuid(player);
+        buf.writeNbt(data);
+    }
+
+    @Override
+    public PacketType<?> getType() {
+        return TYPE;
+    }
+
+    public void handle(ClientPlayerEntity client, PacketSender sender) {
+        PlayerEntity target = client.getWorld().getPlayerByUuid(player);
+        if (target instanceof SuitDataAccess access) {
+            access.timeless$setSuitData(data);
+        }
+    }
+}

--- a/src/main/java/mc/duzo/timeless/power/TogglePower.java
+++ b/src/main/java/mc/duzo/timeless/power/TogglePower.java
@@ -6,7 +6,6 @@ import mc.duzo.timeless.core.items.SuitItem;
 import mc.duzo.timeless.suit.Suit;
 import mc.duzo.timeless.suit.api.EquipSoundSupplier;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
@@ -31,11 +30,7 @@ public abstract class TogglePower<T extends EquipSoundSupplier> extends Power {
 	}
 
 	private void setValue(ServerPlayerEntity player, boolean val, boolean sync) {
-		NbtCompound data = SuitItem.Data.get(player);
-
-		if (data == null) return;
-
-		data.putBoolean(key + "Enabled", val);
+		SuitItem.Data.putBoolean(player, key + "Enabled", val);
 
 		if (sync) {
 			T suit = Suit.findSuit(player)
@@ -58,12 +53,8 @@ public abstract class TogglePower<T extends EquipSoundSupplier> extends Power {
 	}
 
 	public boolean getValue(PlayerEntity player) {
-		NbtCompound data = SuitItem.Data.get(player);
-
-		if (data == null) return false;
-		if (!(data.contains(key + "Enabled"))) return true;
-
-		return data.getBoolean(key + "Enabled");
+		if (!SuitItem.Data.contains(player, key + "Enabled")) return true;
+		return SuitItem.Data.getBoolean(player, key + "Enabled");
 	}
 
 	protected abstract Class<T> getSuitClass();

--- a/src/main/java/mc/duzo/timeless/power/impl/FlightPower.java
+++ b/src/main/java/mc/duzo/timeless/power/impl/FlightPower.java
@@ -12,7 +12,6 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
@@ -120,32 +119,16 @@ public class FlightPower extends Power {
     }
 
     public static boolean hasFlight(PlayerEntity player) {
-        NbtCompound data = SuitItem.Data.get(player);
-
-        if (data == null) return false;
-
-        return data.getBoolean("FlightEnabled");
+        return SuitItem.Data.getBoolean(player, "FlightEnabled");
     }
     public static void setFlight(PlayerEntity player, boolean val) {
-        NbtCompound data = SuitItem.Data.get(player);
-
-        if (data == null) return;
-
-        data.putBoolean("FlightEnabled", val);
+        SuitItem.Data.putBoolean(player, "FlightEnabled", val);
     }
     public static boolean isFlying(PlayerEntity player) {
-        NbtCompound data = SuitItem.Data.get(player);
-
-        if (data == null) return false;
-
-        return data.getBoolean("IsFlying");
+        return SuitItem.Data.getBoolean(player, "IsFlying");
     }
     private static void setIsFlying(PlayerEntity player, boolean val) {
-        NbtCompound data = SuitItem.Data.get(player);
-
-        if (data == null) return;
-
-        data.putBoolean("IsFlying", val);
+        SuitItem.Data.putBoolean(player, "IsFlying", val);
 
         if (player instanceof ServerPlayerEntity)
             Network.toTracking(new UpdateFlyingStatusS2CPacket(player.getUuid(), val), (ServerPlayerEntity) player);

--- a/src/main/java/mc/duzo/timeless/power/impl/HoverPower.java
+++ b/src/main/java/mc/duzo/timeless/power/impl/HoverPower.java
@@ -1,7 +1,6 @@
 package mc.duzo.timeless.power.impl;
 
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
@@ -38,18 +37,10 @@ public class HoverPower extends Power {
     }
 
     private static void setHover(ServerPlayerEntity player, boolean val) {
-        NbtCompound data = SuitItem.Data.get(player);
-
-        if (data == null) return;
-
-        data.putBoolean("HoverEnabled", val);
+        SuitItem.Data.putBoolean(player, "HoverEnabled", val);
     }
     public static boolean hasHover(PlayerEntity player) {
-        NbtCompound data = SuitItem.Data.get(player);
-
-        if (data == null) return false;
-
-        return data.getBoolean("HoverEnabled");
+        return SuitItem.Data.getBoolean(player, "HoverEnabled");
     }
 
     @Override

--- a/src/main/java/mc/duzo/timeless/util/SuitDataAccess.java
+++ b/src/main/java/mc/duzo/timeless/util/SuitDataAccess.java
@@ -1,0 +1,8 @@
+package mc.duzo.timeless.util;
+
+import net.minecraft.nbt.NbtCompound;
+
+public interface SuitDataAccess {
+    NbtCompound timeless$getSuitData();
+    void timeless$setSuitData(NbtCompound nbt);
+}

--- a/src/main/resources/timeless.mixins.json
+++ b/src/main/resources/timeless.mixins.json
@@ -4,7 +4,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "EnchantmentHelperMixin",
-    "EntityMixin"
+    "EntityMixin",
+    "PlayerEntityMixin"
   ],
   "client": [
     "client.ArmorFeatureRendererMixin",

--- a/src/main/resources/timeless.mixins.json
+++ b/src/main/resources/timeless.mixins.json
@@ -5,7 +5,8 @@
   "mixins": [
     "EnchantmentHelperMixin",
     "EntityMixin",
-    "PlayerEntityMixin"
+    "PlayerEntityMixin",
+    "ServerPlayerEntityMixin"
   ],
   "client": [
     "client.ArmorFeatureRendererMixin",


### PR DESCRIPTION
## Problem

Suit toggle state (\`FlightEnabled\`, \`IsFlying\`, \`HoverEnabled\`, \`MaskEnabled\`, \`CapeEnabled\`) used to live on the chestplate \`ItemStack\`'s sub-NBT. The chest stack was the source of truth, and \`SuitItem.Data.get\` was gated on \`getSet().isWearing(...)\`. Three real bugs from this:

- Take off the chestplate -> all toggle state is lost.
- Pick up someone else's chest piece (creative menu, drop on the ground) -> you inherit their toggle state.
- \`Suit.findSuit\` returns a suit if any slot has it, while \`Data.get\` returns \`null\` unless the full set is worn -> partial-set states behave ambiguously (powers tick vs. data lookups silently no-op).

This was Important #9 from the original code review.

## Approach

State now lives on the **player**, not the chestplate.

### New
- \`util/SuitDataAccess.java\` - interface with \`timeless\$getSuitData()\` / \`timeless\$setSuitData(NbtCompound)\`.
- \`mixin/PlayerEntityMixin.java\` - common mixin (covers both \`ServerPlayerEntity\` and \`ClientPlayerEntity\`). Adds a \`@Unique NbtCompound timeless\$suitData\` field, persists via \`@Inject\` into \`writeCustomDataToNbt\` / \`readCustomDataFromNbt\` so it survives save/load.
- \`network/s2c/UpdateSuitDataS2CPacket.java\` - sent to all tracking players whenever any value is written. Client handler updates the corresponding player's \`timeless\$suitData\` so client-side reads (JarvisGui, \`FlightPower.tick(client)\`) see fresh state.
- Registered the new packet receiver in \`ClientNetwork\`.
- Registered the new mixin in \`timeless.mixins.json\`.

### \`SuitItem.Data\` (refactored, same class name)
Reads now go straight to the player's \`SuitDataAccess\`. No more chest-stack lookup, no more \`isWearing\` gate at the data layer.

\`\`\`java
public static NbtCompound get(LivingEntity entity) {
    if (!(entity instanceof SuitDataAccess access)) return null;
    return access.timeless\$getSuitData();
}
\`\`\`

Added convenience helpers that auto-sync on write:

\`\`\`java
SuitItem.Data.putBoolean(player, "FlightEnabled", true);  // mutates + broadcasts S2C packet
SuitItem.Data.getBoolean(player, "FlightEnabled");
SuitItem.Data.contains(player, "FlightEnabled");
SuitItem.Data.sync(player);  // explicit broadcast if needed
```

The old \`set(LivingEntity, String, NbtElement)\` is preserved for the rare case the caller has a typed \`NbtElement\`.

### Call sites
\`TogglePower\`, \`FlightPower\`, \`HoverPower\` all converted from the manual \`if (data == null) return; data.putBoolean(...)\` pattern to \`SuitItem.Data.putBoolean(...)\`. Reads similarly converted to \`SuitItem.Data.getBoolean(...)\`. Several of these methods shrank to one line.

### Where \"is wearing\" gating lives now
At the **power-tick / power-run** sites (\`SuitItem.inventoryTick\` and \`UsePowerC2SPacket.handle\`) - which is where it should be. Both of those already gained the \`isWearing\` check in PR #66. So: state persists across unequip, but powers don't activate unless the full set is worn.

## Behaviour change

State **no longer resets** when you take off the suit. If you had flight enabled and you unequip the chestplate, the state stays. Re-equip the chest -> flight comes back. This was the goal.

If for some reason this is unwanted, it can be flipped by clearing the relevant keys in a chest-unequip hook - but I'd argue this is the more useful behaviour and matches what every other modern mod does.

## Verification

- \`./gradlew compileJava\` clean.
- 9 files touched: 3 new (interface, mixin, packet), 6 modified (mixin config, ClientNetwork, SuitItem, TogglePower, FlightPower, HoverPower).
- No callers of the old \`SuitItem.Data\` chest-NBT contract exist outside this PR (verified via grep).

## Out of scope

- The keys themselves are still string-typed (\"FlightEnabled\", \"HoverEnabled\", etc.). Migrating to \`Identifier\`-keyed or per-power constants is a separate refactor.
- Same for the per-suit-mark vs. global state question (current behaviour: state is global across iron man marks, matches what the chest-NBT design effectively did with generic key names).