### PR TITLE
ci: bump discord-webhook-upload-action to v0.3

### DIFF
--- a/.github/workflows/publish-devbuilds.yml
+++ b/.github/workflows/publish-devbuilds.yml
@@ -49,7 +49,7 @@ jobs:
       #  BETA: 1 # exclude assets if it's a beta dev build
 
     - name: Publish artifacts
-      uses: drtheodor/discord-webhook-upload-action@1959209c809d121da994387257f14502a8350452 # v0.2
+      uses: drtheodor/discord-webhook-upload-action@5d7497d4deb77d02dfb9605f9da85fa780364d00 # v0.3
       with:
         url: ${{ secrets.DEV_BUILDS }}
         username: tony stank


### PR DESCRIPTION
## Summary
- The dev-build CI is failing every push: header message posts to Discord, jar never uploads.
- Root cause: `drtheodor/discord-webhook-upload-action@v0.2` treats Discord's `204 No Content` (the normal success response for a webhook POST without `wait=true`) as an error and aborts before the file step.
- Upstream fixed this in commit [448fefa "204 is not an error, actually"](https://github.com/drtheodor/discord-webhook-upload-action/commit/448fefae), released as v0.3.

## Test plan
- [ ] Merge, then verify the next dev-build run on master both posts the message and attaches the jar