### PR TITLE
ci: fix changelog workflow auth and push target

### DIFF
--- a/.github/workflows/append_changelog.yml
+++ b/.github/workflows/append_changelog.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: append-changelog
+  cancel-in-progress: false
+
 jobs:
   append-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/append_changelog.yml
+++ b/.github/workflows/append_changelog.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     # only proceed if merge event or manual run
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||

--- a/.github/workflows/append_changelog.yml
+++ b/.github/workflows/append_changelog.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   append-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # only proceed if merge event or manual run
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
@@ -23,7 +25,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.BOT_TOKEN }}
+          ref: master
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -36,17 +39,19 @@ jobs:
       - name: Run changelog updater
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: |
           python scripts/update_changelog.py \
             --pr-numbers "${{ github.event.inputs.pr_numbers }}"
       - name: Commit & push
-        env:
-          TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
-          git config user.name "github-bot"
-          git config user.email "bot@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changelog changes to commit."
+            exit 0
+          fi
           git commit -m "docs: update CHANGELOG"
-          git push https://x-access-token:${TOKEN}@github.com/${{ github.repository }} HEAD:${{ github.ref }}
+          git push origin HEAD:master


### PR DESCRIPTION
## About the PR
The post-merge `Update Changelog` workflow has been failing on every merge since #66 because checkout is rejected with `fatal: could not read Username for 'https://github.com'` - the `BOT_TOKEN` secret no longer authenticates. This swaps it to the built-in `GITHUB_TOKEN`, fixes the push target, and only commits when the changelog actually changed.

## Why / Balance
No gameplay impact - CI only. The merged PRs that ran while the workflow was broken (#66, #67, #68, #69, #70, #71, #74, #76) never had their changelog entries appended. Once this lands the workflow can be re-dispatched manually with that PR list to backfill `CHANGELOG.md`.

## Technical details
- `secrets.BOT_TOKEN` -> `secrets.GITHUB_TOKEN` (the bot token is dead; the runner-issued token works and rotates per-run)
- `permissions: contents: write` on the job, since `GITHUB_TOKEN` is read-only by default for `pull_request` events
- `ref: master` on the checkout: when a PR closes, `github.ref` points at `refs/pull/N/merge`, so without this the runner checks out the merge ref and the push target is wrong
- Push target hardcoded to `origin HEAD:master` instead of `${{ github.ref }}`
- Bot identity moved to `github-actions[bot]` (canonical for `GITHUB_TOKEN`-attributed commits)
- Skip the commit step entirely when the diff is empty, so a no-op run does not fail on `git commit`

## Media
N/A - CI only.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

## Backfill plan (post-merge)
After this merges, run:
```
gh workflow run "Update Changelog" --repo amblelabs/superhero -f pr_numbers="66,67,68,69,70,71,74,76"
```
to append the missing entries to `CHANGELOG.md` in one pass.