### PR TITLE
ci: push changelog via deploy key, drop BOT_TOKEN dependency

### DIFF
--- a/.github/workflows/append_changelog.yml
+++ b/.github/workflows/append_changelog.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run changelog updater
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          BOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: |
           python scripts/update_changelog.py \

--- a/.github/workflows/append_changelog.yml
+++ b/.github/workflows/append_changelog.yml
@@ -18,6 +18,9 @@ concurrency:
 jobs:
   append-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     # only proceed if merge event or manual run
     if: |
       (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
@@ -28,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
-          token: ${{ secrets.BOT_TOKEN }}
+          ssh-key: ${{ secrets.CHANGELOG_DEPLOY_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -41,14 +44,12 @@ jobs:
       - name: Run changelog updater
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: |
           python scripts/update_changelog.py \
             --pr-numbers "${{ github.event.inputs.pr_numbers }}"
       - name: Commit & push
-        env:
-          TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           git config user.name "github-bot"
           git config user.email "bot@users.noreply.github.com"
@@ -58,4 +59,4 @@ jobs:
             exit 0
           fi
           git commit -m "docs: update CHANGELOG"
-          git push https://x-access-token:${TOKEN}@github.com/${{ github.repository }} HEAD:master
+          git push origin HEAD:master

--- a/.github/workflows/append_changelog.yml
+++ b/.github/workflows/append_changelog.yml
@@ -8,8 +8,7 @@ on:
     inputs:
       pr_numbers:
         description: 'Comma-separated PR numbers to process (e.g. "12,47")'
-        required: false
-        default: ''
+        required: true
 
 concurrency:
   group: append-changelog

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -8,7 +8,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 repo = os.environ["GITHUB_REPOSITORY"]
-token = os.environ["BOT_TOKEN"]
+token = os.environ["GH_TOKEN"]
 headers = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github.v3+json"}
 
 # Fetch PR metadata


### PR DESCRIPTION
## About the PR
Follow-up to #77 and #78. The post-merge changelog workflow has been chasing a moving target: `GITHUB_TOKEN` is blocked by the `PRS ONLY` ruleset, fine-grained PATs don't carry team membership for ruleset bypass, and the built-in `github-actions` integration cannot be added as a bypass `Integration` actor (must be installed at org level). The ruleset already lists `DeployKey` (any) with `bypass_mode: always`, so this swaps to a deploy-key-driven push and removes this workflow's PAT dependency.

## Why / Balance
No gameplay impact - CI only. Restores reliable post-merge changelog updates and removes a recurring failure mode tied to PAT lifetime.

## Technical details
- `actions/checkout` now uses `ssh-key: ${{ secrets.CHANGELOG_DEPLOY_KEY }}`. That single setting auths the clone over SSH *and* configures `origin` to use SSH, so the later `git push origin HEAD:master` rides the same key
- Drop every `BOT_TOKEN` reference in `.github/workflows/append_changelog.yml`. The Python updater needs a token only to read PR metadata via `/pulls/{n}` and `/pulls/{n}/commits`, so it now reads `secrets.GITHUB_TOKEN` (which has full read for `pull_request_target` and `workflow_dispatch`)
- Rename the env var to `GH_TOKEN` so the name reflects what's actually injected, with a matching update to `scripts/update_changelog.py`
- Tighten the job's `permissions:` to `contents: read` + `pull-requests: read` - we no longer need write on the auto-issued token, the deploy key handles writes
- Make `pr_numbers` required for manual dispatch - the script falls back to the event payload's `pull_request` field when the list is empty, which doesn't exist on `workflow_dispatch` events

`.github/workflows/clear_changelog.yml` still references `BOT_TOKEN`, but it triggers on PRs to a `release` branch that doesn't exist in this repo today, so it's dormant. Out of scope here; can migrate it the same way if/when `release` comes back.

## Setup (out of band)
A repo deploy key named `Changelog bot` has been added with write access enabled, and its private half is stored as repo secret `CHANGELOG_DEPLOY_KEY`. The expired `BOT_TOKEN` PAT can be revoked once this lands.

## Media
N/A - CI only.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

## Backfill plan (post-merge)
```
gh workflow run "Update Changelog" --repo amblelabs/superhero -f pr_numbers="66,67,68,69,70,71,74,76,77,78"
```